### PR TITLE
Language code is the same as in filename

### DIFF
--- a/TinyMce.php
+++ b/TinyMce.php
@@ -159,7 +159,6 @@ class TinyMce extends InputWidget
                 $this->settings['language'] = 'en';
             }
         }
-        $this->settings['language'] = strtr($this->settings['language'], '_', '-');
 
         $assetsDir = $this->getView()->getAssetManager()->getBundle(TinyMceAsset::className())->baseUrl;
         $this->settings['script_url'] = "{$assetsDir}/tiny_mce.js";


### PR DESCRIPTION
Replacing "_" with "-" breaks the plugin when using language code "nb_NO". Removing this line makes it work.
